### PR TITLE
(PXP-6544) Pelican-export allows client to specify the root node

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,10 +1,9 @@
 {
-  "custom_plugin_paths": [],
   "exclude": {
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-07-24T04:28:36Z",
+  "generated_at": "2020-09-03T16:48:53Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -69,7 +68,7 @@
       }
     ]
   },
-  "version": "0.14.1",
+  "version": "0.13.1",
   "word_list": {
     "file": null,
     "hash": null

--- a/job_export.py
+++ b/job_export.py
@@ -18,9 +18,13 @@ if __name__ == "__main__":
     node = os.environ["ROOT_NODE"]
     access_token = os.environ["ACCESS_TOKEN"]
     input_data = os.environ["INPUT_DATA"]
+    input_data = json.loads(input_data)
 
-    gql = GuppyGQL(node=node, hostname="http://revproxy-service", access_token=access_token)
-    case_ids = gql.execute(filters=input_data)
+    gql = GuppyGQL(
+        node=node, hostname="http://revproxy-service", access_token=access_token
+    )
+    filters = {"filters": input_data["filter"]}
+    case_ids = gql.execute(filters=filters)
 
     with open("/peregrine-creds.json") as pelican_creds_file:
         peregrine_creds = json.load(pelican_creds_file)
@@ -35,17 +39,29 @@ if __name__ == "__main__":
     dictionary, model = init_dictionary(url=dictionary_url)
     ddt = DataDictionaryTraversal(model)
 
-    if "gtex" in dictionary_url:
-        extra_nodes = ["reference_file", "reference_file_index"]
+    # EXTRA_NODES is an optional comma-delimited list of nodes to additionally include in the PFB.
+    if os.environ.get("EXTRA_NODES") is not None:
+        # Allow user to specify EXTRA_NODES == None by passing an empty string.
+        # This is so that BioDataCatalyst PFB exports can specify no extra nodes.
+        if os.environ["EXTRA_NODES"].strip() == "":
+            extra_nodes = None
+        else:
+            extra_nodes = [n for n in os.environ["EXTRA_NODES"].split(",")]
     else:
-        extra_nodes = None
+        # Preserved for backwards compatibility:
+        # If EXTRA_NODES is not specified, add 'reference_file' node
+        # when exporting PFBs from BioDataCatalyst (aka STAGE aka gtex)
+        if "gtex" in dictionary_url:
+            extra_nodes = ["reference_file", "reference_file_index"]
+        else:
+            extra_nodes = None
 
     conf = (
         SparkConf()
-            .set("spark.jars", os.environ["POSTGRES_JAR_PATH"])
-            .set("spark.driver.memory", "10g")
-            .set("spark.executor.memory", "10g")
-            .setAppName("pelican")
+        .set("spark.jars", os.environ["POSTGRES_JAR_PATH"])
+        .set("spark.driver.memory", "10g")
+        .set("spark.executor.memory", "10g")
+        .setAppName("pelican")
     )
 
     spark = SparkSession.builder.config(conf=conf).getOrCreate()
@@ -66,6 +82,12 @@ if __name__ == "__main__":
                 pfb_file.write()
                 fname = pfb_file.name
 
+    # If the input data specifies the root node to use, use
+    # that root node. Otherwise fall back to $ROOT_NODE environment variable.
+    root_node = input_data.get("root_node")
+    if root_node is None:
+        root_node = node
+
     with open(fname, "a+b") as avro_output:
         with PFBReader(filename) as reader:
             with PFBWriter(avro_output) as pfb_file:
@@ -75,21 +97,23 @@ if __name__ == "__main__":
                     pfb_file,
                     ddt,
                     case_ids,
-                    node,
+                    root_node,
                     extra_nodes,
-                    True  # include upward nodes: project, program etc
+                    True,  # include upward nodes: project, program etc
                 )
 
     with open("/pelican-creds.json") as pelican_creds_file:
         pelican_creds = json.load(pelican_creds_file)
 
-    avro_filename = "{}.avro".format(datetime.now().strftime('export_%Y-%m-%dT%H:%M:%S'))
+    avro_filename = "{}.avro".format(
+        datetime.now().strftime("export_%Y-%m-%dT%H:%M:%S")
+    )
     s3file = s3upload_file(
         pelican_creds["manifest_bucket_name"],
         avro_filename,
         pelican_creds["aws_access_key_id"],
         pelican_creds["aws_secret_access_key"],
-        fname
+        fname,
     )
 
     print("[out] {}".format(s3file))

--- a/job_export.py
+++ b/job_export.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
     gql = GuppyGQL(
         node=node, hostname="http://revproxy-service", access_token=access_token
     )
-    filters = {"filters": input_data["filter"]}
+    filters = json.dumps({"filter": input_data["filter"]})
     case_ids = gql.execute(filters=filters)
 
     with open("/peregrine-creds.json") as pelican_creds_file:


### PR DESCRIPTION
Link to Jira: [PXP-6544](https://ctds-planx.atlassian.net/browse/PXP-6544)
Link to design doc: https://docs.google.com/document/d/12FkAYOpDuSdQScEgYBxXsPUdm8GUuUZgD6xU7EQga5A/edit#
Link to related portal PR: https://github.com/uc-cdis/data-portal/pull/729

### New Features
- Pelican-export job now allows client to specify the root node of a pfb when dispatching a job, allowing clients to export PFBs of entities that are not on the $ROOT_NODE environment variable. This allows for exporting of data file PFBs, so long as the data files are all on the same root node. 
- The pelican-export algorithm's extra_nodes input can now be configured by $EXTRA_NODES environment variable. The old behavior of including `reference_file` and `reference_file_index` for BDCat exports is still there for backwards compatibility.

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
