### PR TITLE
fix(april-release): Revert updating pypfb version and lowering gen3datamodel (PR #40)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -197,15 +197,15 @@ test = ["pytest (>=6.0)", "pytest-cov", "pytest-subtests", "pytest-xdist", "pret
 
 [[package]]
 name = "dictionaryutils"
-version = "3.4.1"
-description = "Python wrapper and metaschema for datadictionary."
+version = "3.0.0"
+description = ""
 category = "main"
 optional = false
-python-versions = ">=3.6,<3.8"
+python-versions = "*"
 
 [package.dependencies]
-cdislogging = ">=1.0.0,<2.0.0"
-jsonschema = ">=2.5,<4.0"
+cdislogging = ">=1.0,<2.0"
+jsonschema = ">=2.5.1"
 PyYAML = ">=5.1,<6.0"
 requests = ">=2.18,<3.0"
 
@@ -391,18 +391,19 @@ test = ["flake8 (>=3.8.4,<3.9.0)", "pycodestyle (>=2.6.0,<2.7.0)"]
 
 [[package]]
 name = "importlib-metadata"
-version = "1.7.0"
+version = "4.0.0"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+python-versions = ">=3.6"
 
 [package.dependencies]
+typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["sphinx", "rst.linker"]
-testing = ["packaging", "pep517", "importlib-resources (>=1.3)"]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "indexclient"
@@ -575,23 +576,19 @@ test = ["flaky", "pretend", "pytest (>=3.0.1)"]
 
 [[package]]
 name = "pypfb"
-version = "0.5.8"
+version = "0.4.2"
 description = "Python SDK for PFB format"
 category = "main"
 optional = false
-python-versions = ">=3.6.1,<3.8"
+python-versions = "*"
 
 [package.dependencies]
-aiohttp = ">=3.6.3,<4.0.0"
-click = ">=7.1.2,<8.0.0"
-dictionaryutils = ">=3.2.0,<4.0.0"
-fastavro = ">=1.0.0,<2.0.0"
-gdcdictionary = ">=1.2.0,<2.0.0"
-gen3 = ">=4.2.0,<5.0.0"
-importlib_metadata = {version = ">=1.3.0,<2.0.0", markers = "python_version < \"3.8\""}
-pandas = ">=1.1.0,<2.0.0"
-python-json-logger = ">=0.1.11,<0.2.0"
-PyYAML = ">=5.3.1,<6.0.0"
+click = ">=7.0,<8.0"
+dictionaryutils = ">=3.0"
+fastavro = ">=0.21"
+gdcdictionary = ">=1.2.0"
+python-json-logger = ">=0.1,<1.0"
+PyYAML = ">=5.1,<6.0"
 
 [[package]]
 name = "pyspark"
@@ -806,7 +803,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.1,<3.8"
-content-hash = "9762360d46a2752dbde05058d9db567ae750dbabc47a9d8f509efaef7bb8b6c5"
+content-hash = "316c5799b350b1e9bd8a9f80954a5e17b9c3874ed3b673fa2a1eabf6fd5eb650"
 
 [metadata.files]
 aiohttp = [
@@ -956,7 +953,8 @@ cryptography = [
     {file = "cryptography-3.4.7.tar.gz", hash = "sha256:3d10de8116d25649631977cb37da6cbdd2d6fa0e0281d014a5b7d337255ca713"},
 ]
 dictionaryutils = [
-    {file = "dictionaryutils-3.4.1.tar.gz", hash = "sha256:4e108564763ecdbc75a3736647f6b3b5af2af237ca0c8bdb3b21d240d2b19474"},
+    {file = "dictionaryutils-3.0.0-py3.6.egg", hash = "sha256:114cac7ff5e98b9d04e4e9eff340ed8489f10bdb64c144c31e74573aabdfe081"},
+    {file = "dictionaryutils-3.0.0.tar.gz", hash = "sha256:900dc103561141e09e65daf1d39f1f781a43e1fd20655281cc48adac17f6f4fc"},
 ]
 drsclient = [
     {file = "drsclient-0.1.4.tar.gz", hash = "sha256:315f7ed7bc75348d33a3ac28c8c0efda03850f32a6abca4b5b69d4b73fb50c92"},
@@ -1077,8 +1075,8 @@ immutables = [
     {file = "immutables-0.15.tar.gz", hash = "sha256:3713ab1ebbb6946b7ce1387bb9d1d7f5e09c45add58c2a2ee65f963c171e746b"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-1.7.0-py2.py3-none-any.whl", hash = "sha256:dc15b2969b4ce36305c51eebe62d418ac7791e9a157911d58bfb1f9ccd8e2070"},
-    {file = "importlib_metadata-1.7.0.tar.gz", hash = "sha256:90bb658cdbbf6d1735b6341ce708fc7024a3e14e99ffdc5783edea9f9b077f83"},
+    {file = "importlib_metadata-4.0.0-py3-none-any.whl", hash = "sha256:19192b88d959336bfa6bdaaaef99aeafec179eca19c47c804e555703ee5f07ef"},
+    {file = "importlib_metadata-4.0.0.tar.gz", hash = "sha256:2e881981c9748d7282b374b68e759c87745c25427b67ecf0cc67fb6637a1bff9"},
 ]
 indexclient = [
     {file = "indexclient-2.1.0.tar.gz", hash = "sha256:777476eb97febfcd663b7f9454fba5151dee4d17254bfa0dfb5ff040c59b8532"},
@@ -1303,8 +1301,7 @@ pyopenssl = [
     {file = "pyOpenSSL-20.0.1.tar.gz", hash = "sha256:4c231c759543ba02560fcd2480c48dcec4dae34c9da7d3747c508227e0624b51"},
 ]
 pypfb = [
-    {file = "pypfb-0.5.8-py3-none-any.whl", hash = "sha256:74cc1d739178a1cca04e5b36316fda6ad4815d3f09716ff2fd8077d7e1b55dce"},
-    {file = "pypfb-0.5.8.tar.gz", hash = "sha256:63e2ffcd32cc8e6d840fdaffd7d000016af9399ad6bdd6753601319e38ebdb36"},
+    {file = "pypfb-0.4.2.tar.gz", hash = "sha256:2879e826dc1f6a4ab9cb1688007306225f86913629d404f45c0e2d73ed9f1dcd"},
 ]
 pyspark = [
     {file = "pyspark-3.1.1.tar.gz", hash = "sha256:104abc146d4ffb72d4c683d25d7af5a6bf955d94590a76f542ee23185670aa7e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pelican"
-version = "0.6.0"
+version = "0.6.1"
 description = ""
 authors = ["CTDS UChicago <cdis@uchicago.edu>"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["CTDS UChicago <cdis@uchicago.edu>"]
 
 [tool.poetry.dependencies]
 python = ">=3.6.1,<3.8"
-pypfb = "^0.5.7"
+pypfb = ">=0.4.0,<0.5.0"
 fastavro = "^1.3.1"
 requests = "^2.25.1"
 psycopg2-binary = "^2.8.6"
@@ -15,8 +15,8 @@ psutil = "^5.8.0"
 boto3 = "^1.17.7"
 gen3 = "^4.2.0"
 psqlgraph = "3.0.1"
-gen3datamodel = "<3.0.2"
-dictionaryutils = "^3.4.1"
+gen3datamodel = ">=3.0.0,<4.0.0"
+dictionaryutils = "<=3.0.2"
 SQLAlchemy = "^1.4.9"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Revert updating pypfb version and lowering gen3datamodel (PR #40)

The 2021.04 version is failing due to:
```
Writing PFB...
Traceback (most recent call last):
  File "job_export.py", line 83, in <module>
    _from_dict(pfb_file, dictionary_url)
  File "/usr/local/lib/python3.7/site-packages/pfb/importers/gen3dict.py", line 49, in _from_dict
    writer.write()
  File "/usr/local/lib/python3.7/site-packages/pfb/writer.py", line 240, in write
    writer(self._file_obj, make_avro_schema(self.schema), _iter())
  File "fastavro/_write.pyx", line 714, in fastavro._write.writer
  File "fastavro/_write.pyx", line 601, in fastavro._write.Writer.__init__
  File "fastavro/_schema.pyx", line 95, in fastavro._schema.parse_schema
  File "fastavro/_schema.pyx", line 232, in fastavro._schema._parse_schema
  File "fastavro/_schema.pyx", line 277, in fastavro._schema.parse_field
  File "fastavro/_schema.pyx", line 104, in fastavro._schema._parse_schema
  File "fastavro/_schema.pyx", line 232, in fastavro._schema._parse_schema
  File "fastavro/_schema.pyx", line 277, in fastavro._schema.parse_field
  File "fastavro/_schema.pyx", line 104, in fastavro._schema._parse_schema
  File "fastavro/_schema.pyx", line 118, in fastavro._schema._parse_schema
fastavro._schema_common.UnknownType: array
```