### PR TITLE
PXP-8458 Fix/vcf extra nodes

### DIFF
--- a/job_export.py
+++ b/job_export.py
@@ -99,7 +99,10 @@ if __name__ == "__main__":
 
     # adding aligned_reads_index to the extra nodes on VCF files to make them inline with CRAM files
     if root_node == "simple_germline_variation":
-        extra_nodes.append("aligned_reads_index")
+        if extra_nodes is None:
+            extra_nodes = ["aligned_reads_index"]
+        else:
+            extra_nodes.append("aligned_reads_index")
 
     with open(fname, "a+b") as avro_output:
         with PFBReader(filename) as reader:

--- a/job_export.py
+++ b/job_export.py
@@ -97,6 +97,10 @@ if __name__ == "__main__":
     if root_node is None:
         root_node = node
 
+    # adding aligned_reads_index to the extra nodes on VCF files to make them inline with CRAM files
+    if root_node == "simple_germline_variation":
+        extra_nodes.append("aligned_reads_index")
+
     with open(fname, "a+b") as avro_output:
         with PFBReader(filename) as reader:
             with PFBWriter(avro_output) as pfb_file:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pelican"
-version = "0.6.3"
+version = "0.6.4"
 description = ""
 authors = ["CTDS UChicago <cdis@uchicago.edu>"]
 


### PR DESCRIPTION
### Bug Fixes
- adding aligned_reads_index to the extra nodes on VCF file exports to make them inline with CRAM files
