### PR TITLE
PXP-10558 Pelican export: store PFB file's `_expires_at` in MDS

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,6 @@ repos:
     -   id: no-commit-to-branch
         args: [--branch, develop, --branch, master, --pattern, release/.*]
 -   repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 22.12.0
     hooks:
     -   id: black

--- a/docs/pelican-export.md
+++ b/docs/pelican-export.md
@@ -27,6 +27,8 @@ Start the Sower job by hitting the `POST <base URL>/job/dispatch` endpoint with 
 
 ## Setup
 
+TODO update
+
 1. Run `gen3 kube-setup-pelicanjob`. This will create the S3 bucket for exported PFB files.
 2. Setup and install [Sower](https://github.com/uc-cdis/sower).
 3. Update the manifest to include the configuration for the `pelican-export` job:

--- a/docs/pelican-export.md
+++ b/docs/pelican-export.md
@@ -27,11 +27,14 @@ Start the Sower job by hitting the `POST <base URL>/job/dispatch` endpoint with 
 
 ## Setup
 
-TODO update
-
-1. Run `gen3 kube-setup-pelicanjob`. This will create the S3 bucket for exported PFB files.
-2. Setup and install [Sower](https://github.com/uc-cdis/sower).
-3. Update the manifest to include the configuration for the `pelican-export` job:
+1. This job should be deployed alongside the `metadata-delete-expired-objects` cronjob:
+    - Add `"metadata-delete-expired-objects": "quay.io/cdis/metadata-delete-expired-objects:<version>"` to the `versions` block of the manifest.
+    - Run `gen3 kube-setup-metadata-delete-expired-objects-cronjob`.
+    - Grant the `metadata-delete-expired-objects-job` client access to `(resource=/mds_gateway, method=access, service=mds_gateway)` and `(resource=/programs, method=delete, service=fence)` in the `user.yaml`.
+2. Run `gen3 kube-setup-pelicanjob`. This will create the S3 bucket for exported PFB files and the Fence client for submitting to the metadata service.
+3. Grant the `pelican-export-job` client access to `(resource=/mds_gateway, method=access, service=mds_gateway)` in the `user.yaml`.
+4. Set up and deploy [Sower](https://github.com/uc-cdis/sower).
+5. Update the manifest to include the configuration for the `pelican-export` job:
 
 ##### Manifest configuration
 

--- a/job_export.py
+++ b/job_export.py
@@ -15,7 +15,7 @@ from pelican.dictionary import init_dictionary, DataDictionaryTraversal
 from pelican.graphql.guppy_gql import GuppyGQL
 from pelican.jobs import export_pfb_job
 from pelican.s3 import s3upload_file
-from pelican.indexd import indexd_submit, indexd_delete
+from pelican.indexd import indexd_submit
 from pelican.mds import metadata_submit
 
 if __name__ == "__main__":
@@ -28,6 +28,17 @@ if __name__ == "__main__":
 
     print("This is the format")
     print(access_format)
+
+    with open("/pelican-creds.json") as pelican_creds_file:
+        pelican_creds = json.load(pelican_creds_file)
+    for key in [
+        "manifest_bucket_name",
+        "aws_access_key_id",
+        "aws_secret_access_key",
+        "fence_client_id",
+        "fence_client_secret",
+    ]:
+        assert pelican_creds.get("key"), f"No '{key}' in config"
 
     input_data = json.loads(input_data)
 
@@ -120,9 +131,6 @@ if __name__ == "__main__":
                     True,  # include upward nodes: project, program etc
                 )
 
-    with open("/pelican-creds.json") as pelican_creds_file:
-        pelican_creds = json.load(pelican_creds_file)
-
     avro_filename = "{}.avro".format(
         datetime.now().strftime("export_%Y-%m-%dT%H:%M:%S")
     )
@@ -174,6 +182,8 @@ if __name__ == "__main__":
             {"md5": str(md5_digest)},
             authz,
         )
+
+        # TODO use pelican_creds["fence_client_id"] pelican_creds["fence_client_secret"]
         metadata_submit(
             hostname=COMMONS,
             guid=indexd_record["did"],

--- a/job_export.py
+++ b/job_export.py
@@ -15,13 +15,16 @@ from pelican.dictionary import init_dictionary, DataDictionaryTraversal
 from pelican.graphql.guppy_gql import GuppyGQL
 from pelican.jobs import export_pfb_job
 from pelican.s3 import s3upload_file
-from pelican.indexd import indexd_submit
+from pelican.indexd import indexd_submit, indexd_delete
+from pelican.mds import metadata_submit
 
 if __name__ == "__main__":
     node = os.environ["ROOT_NODE"]
     access_token = os.environ["ACCESS_TOKEN"]
     input_data = os.environ["INPUT_DATA"]
     access_format = os.environ["ACCESS_FORMAT"]
+    # the PFB file and indexd/mds records expire after 14 days by default
+    record_expiration_days = os.environ.get("RECORD_EXPIRATION_DAYS", 14)
 
     print("This is the format")
     print(access_format)
@@ -170,6 +173,12 @@ if __name__ == "__main__":
             [s3_url],
             {"md5": str(md5_digest)},
             authz,
+        )
+        metadata_submit(
+            hostname=COMMONS,
+            guid=indexd_record["did"],
+            access_token=access_token,
+            record_expiration_days=record_expiration_days,
         )
 
         # send s3 link and information to indexd to create guid and send it back

--- a/job_export.py
+++ b/job_export.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
         "fence_client_id",
         "fence_client_secret",
     ]:
-        assert pelican_creds.get("key"), f"No '{key}' in config"
+        assert pelican_creds.get(key), f"No '{key}' in config"
 
     input_data = json.loads(input_data)
 

--- a/pelican/indexd.py
+++ b/pelican/indexd.py
@@ -1,6 +1,5 @@
 import requests
 import json
-import base64
 
 
 def indexd_submit(

--- a/pelican/mds.py
+++ b/pelican/mds.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 import requests
 
 
-def metadata_submit(hostname, guid, access_token, record_expiration_days):
+def metadata_submit_expiration(hostname, guid, access_token, record_expiration_days):
     expires_at = (datetime.now() + timedelta(days=record_expiration_days)).timestamp()
     r = requests.post(
         f"{hostname}mds/metadata/{guid}",

--- a/pelican/mds.py
+++ b/pelican/mds.py
@@ -15,7 +15,7 @@ def metadata_submit_expiration(hostname, guid, access_token, record_expiration_d
         json=body,
         headers={"Authorization": f"bearer {access_token}"},
     )
-    if r.status_code != 200:
+    if r.status_code != 201:
         raise Exception(
             f"Submission to metadata-service failed with {r.status_code}:\n{r.text}"
         )

--- a/pelican/mds.py
+++ b/pelican/mds.py
@@ -1,0 +1,17 @@
+from datetime import datetime, timedelta
+import requests
+
+
+def metadata_submit(hostname, guid, access_token, record_expiration_days):
+    expires_at = (datetime.now() + timedelta(days=record_expiration_days)).timestamp()
+    r = requests.post(
+        f"{hostname}mds/metadata/{guid}",
+        json={"_expires_at": expires_at},
+        # headers={"content-type": "application/json"},
+        # auth=("gdcapi", str(access_token)),
+        headers={"Authorization": f"bearer {access_token}"},
+    )
+    if r.status_code != 200:
+        raise Exception(
+            f"Submission to metadata-service failed with {r.status_code}:\n{r.text}"
+        )

--- a/pelican/mds.py
+++ b/pelican/mds.py
@@ -3,14 +3,13 @@ import requests
 
 
 def metadata_submit_expiration(hostname, guid, access_token, record_expiration_days):
+    expires_at = (datetime.now() + timedelta(days=record_expiration_days)).timestamp()
     url = f"{hostname}mds/metadata/{guid}"
     body = {"_expires_at": expires_at}
     print("-----------------------------------------------------")
     print(url)
     print(body)
     print("-----------------------------------------------------")
-
-    expires_at = (datetime.now() + timedelta(days=record_expiration_days)).timestamp()
     r = requests.post(
         url,
         json=body,

--- a/pelican/mds.py
+++ b/pelican/mds.py
@@ -3,12 +3,17 @@ import requests
 
 
 def metadata_submit_expiration(hostname, guid, access_token, record_expiration_days):
+    url = f"{hostname}mds/metadata/{guid}"
+    body = {"_expires_at": expires_at}
+    print("-----------------------------------------------------")
+    print(url)
+    print(body)
+    print("-----------------------------------------------------")
+
     expires_at = (datetime.now() + timedelta(days=record_expiration_days)).timestamp()
     r = requests.post(
-        f"{hostname}mds/metadata/{guid}",
-        json={"_expires_at": expires_at},
-        # headers={"content-type": "application/json"},
-        # auth=("gdcapi", str(access_token)),
+        url,
+        json=body,
         headers={"Authorization": f"bearer {access_token}"},
     )
     if r.status_code != 200:


### PR DESCRIPTION
Jira Ticket: [PXP-10558](https://ctds-planx.atlassian.net/browse/PXP-10558)

see https://github.com/uc-cdis/cloud-automation/pull/2153

### New Features
- Pelican export: store the generated PFB files' `_expires_at` timestamp in MDS (set to 14 days after creation) so they can be deleted once expired

### Breaking Changes
- The Pelican export job now requires access to submit data in MDS. In cloud-automation setups, run `kubectl delete secrets pelicanservice-g3auto`, `rm Gen3Secrets/g3auto/pelicanservice/config.json` and `gen3 kube-setup-pelicanjob`. Then, grant the `pelican-export-job` client access to `(resource=/mds_gateway, method=access, service=mds_gateway)` in the `user.yaml`.

### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
- The Pelican export job should now be deployed alongside the `metadata-delete-expired-objects` cronjob: add `"metadata-delete-expired-objects": "quay.io/cdis/metadata-delete-expired-objects:<version>"` to the `versions` block of the manifest., run `gen3 kube-setup-metadata-delete-expired-objects-cronjob` and grant the `metadata-delete-expired-objects-job` client access to `(resource=/mds_gateway, method=access, service=mds_gateway)` and `(resource=/programs, method=delete, service=fence)` in the `user.yaml`.


[PXP-10558]: https://ctds-planx.atlassian.net/browse/PXP-10558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ