### PR TITLE
fix download endpoint error

### DIFF
--- a/pelican/graphql/base_gql.py
+++ b/pelican/graphql/base_gql.py
@@ -14,11 +14,6 @@ class BaseGQL:
         raise NotImplementedError
 
     def _execute(self, query):
-        # Ensure that the variables are encoded for the POST request
-        var = query["variables"]
-        var = json.loads(var)
-        query["variables"] = var
-
         r = requests.post(self.url, json=query, headers=self.headers)
         
         if r.status_code == 200:

--- a/pelican/graphql/guppy_gql.py
+++ b/pelican/graphql/guppy_gql.py
@@ -40,6 +40,11 @@ class GuppyGQL(BaseGQL):
         query_json = {"query": query}
         if filters:
             query_json["variables"] = filters
+            # Ensure that the variables are encoded for the POST request
+            var = query_json["variables"]
+            var = json.loads(var)
+            query_json["variables"] = var
+
         r = BaseGQL._execute(self, query_json)
         try:
             r = r["data"][self.node]


### PR DESCRIPTION
This PR solved a bug introduced by `https://github.com/uc-cdis/pelican/commit/df39b7447cc7d5d0e20121bff5fa1ebe25221173#diff-10e55fb7c7414852af70a092f635a354071c8102118d14c94199ca5f06f8bd36`.

The download endpoint calls the filters `filters` instead of `variables`. Should I add `json.loads` also for the download endpoint?

```
Skipping virtualenv creation, as specified in config file.
This is the format
presigned_url
Traceback (most recent call last):
  File "/pelican/job_export.py", line 54, in <module>
fallback to /download endpoint
    case_ids = gql.execute(filters=filters)
  File "/pelican/pelican/graphql/guppy_gql.py", line 70, in execute
    self._download_endpoint(filters)
  File "/pelican/pelican/graphql/guppy_gql.py", line 34, in _download_endpoint
    r = BaseGQL._execute(self, query)
  File "/pelican/pelican/graphql/base_gql.py", line 18, in _execute
    var = query["variables"]
KeyError: 'variables'
```