### PR TITLE
Update job_export.py

### DIFF
--- a/job_export.py
+++ b/job_export.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     DB_USER = os.getenv("DB_USER")
     DB_PASS = os.getenv("DB_PASS")
     DB_URL = f"jdbc:postgresql://{DB_HOST}/{DB_DATABASE}"
-        
+
     dictionary_url = os.environ["DICTIONARY_URL"]
     dictionary, model = init_dictionary(url=dictionary_url)
     ddt = DataDictionaryTraversal(model)
@@ -167,9 +167,7 @@ if __name__ == "__main__":
         hostname = os.environ["GEN3_HOSTNAME"]
         COMMONS = "https://" + hostname + "/"
 
-        # try sending to indexd
-        with open("/indexd-creds.json") as indexd_creds_file:
-            indexd_creds = json.load(indexd_creds_file)
+        indexd_creds = os.getenv("SHEEPDOG")
 
         s3_url = "s3://" + pelican_creds["manifest_bucket_name"] + "/" + avro_filename
 
@@ -189,7 +187,7 @@ if __name__ == "__main__":
 
         indexd_record = indexd_submit(
             COMMONS,
-            indexd_creds["user_db"]["gdcapi"],
+            indexd_creds,
             avro_filename,
             os.stat(fname).st_size,
             [s3_url],

--- a/job_export.py
+++ b/job_export.py
@@ -50,15 +50,13 @@ if __name__ == "__main__":
     filters = json.dumps({"filter": input_data.get("filter", {})})
     case_ids = gql.execute(filters=filters)
 
-    with open("/peregrine-creds.json") as pelican_creds_file:
-        peregrine_creds = json.load(pelican_creds_file)
-
-    DB_URL = "jdbc:postgresql://{}/{}".format(
-        peregrine_creds["db_host"], peregrine_creds["db_database"]
-    )
-    DB_USER = peregrine_creds["db_username"]
-    DB_PASS = peregrine_creds["db_password"]
-
+    # Get Peregrine creds via environment variables
+    DB_HOST = os.getenv("DB_HOST")
+    DB_DATABASE = os.getenv("DB_DATABASE")
+    DB_USER = os.getenv("DB_USER")
+    DB_PASS = os.getenv("DB_PASS")
+    DB_URL = f"jdbc:postgresql://{DB_HOST}/{DB_DATABASE}"
+        
     dictionary_url = os.environ["DICTIONARY_URL"]
     dictionary, model = init_dictionary(url=dictionary_url)
     ddt = DataDictionaryTraversal(model)


### PR DESCRIPTION
Our Helm charts utilize eternal secrets to create and manage our secrets. The new Peregrine-dbcreds secret is formatted differently and no longer uses json, so we need to edit the export job so the values can be read via environment variables.
